### PR TITLE
Zabezpieczenie przed manipulacją daty utworzenia zadania

### DIFF
--- a/backend/src/models/task.ts
+++ b/backend/src/models/task.ts
@@ -11,12 +11,15 @@ export interface TaskInterface extends Document {
 }
 
 export const TaskSchema: Schema = new Schema({
-    title: {type: String, required: true},
-    details: {type: String, required: false},
-    inProgress: {type: Boolean, required: true},
-    priority: {type: String, required: true},
-    deadlineDate: {type: Date, required: false},
-});
+        title: {type: String, required: true},
+        details: {type: String, required: false},
+        inProgress: {type: Boolean, required: true},
+        priority: {type: String, required: true},
+        deadlineDate: {type: Date, required: false},
+    },
+    {
+        timestamps: {createdAt: true, updatedAt: false}
+    });
 
 const Task = mongoose.model<TaskInterface>("Task", TaskSchema);
 export default Task;

--- a/backend/src/models/task.ts
+++ b/backend/src/models/task.ts
@@ -15,8 +15,6 @@ export const TaskSchema: Schema = new Schema({
     details: {type: String, required: false},
     inProgress: {type: Boolean, required: true},
     priority: {type: String, required: true},
-    // TODO: disable custom creation date (use default always)
-    creationDate: {type: Date, default: () => Date.now()},
     deadlineDate: {type: Date, required: false},
 });
 


### PR DESCRIPTION
Nie musimy mieć daty utworzenia w modelu, bo timestamp łatwo wyciągnąć z _ObjectId_.
[Tutaj](https://steveridout.github.io/mongo-object-time/) można wypróbować, próbowałam też u nas mniej więcej tak: 

> const timestamp = task._id.toString().substring(0,8);
                const date = new Date( parseInt( timestamp, 16 ) * 1000 );

Musimy tylko pamiętać że mamy mieć UTC+2.

[ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/)
[ObjectId.getTimestamp](https://docs.mongodb.com/manual/reference/method/ObjectId.getTimestamp/)
