### PR TITLE
Wyświetlanie Snackbara na poziomie całej aplikacji

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -5,14 +5,16 @@ import { Theme } from '@react-navigation/native/src/types';
 import ListContainer from './src/components/list/ListContainer';
 import DetailsContainer from './src/components/details/DetailsContainer';
 import SettingsContainer from './src/components/settings/SettingsContainer';
+import StyledSnackbar from './src/components/ui/StyledSnackbar';
 import { colors, darkTheme, lightTheme } from './src/styles/common';
-import { SortingContext, ThemeContext } from './src/utils/context';
+import { SnackbarContext, SortingContext, ThemeContext } from './src/utils/context';
 
 const Stack = createStackNavigator();
 
 interface State {
   currentTheme: Theme,
   currentSorting: string,
+  snackbarMessage: string | null,
 }
 
 class App extends React.Component<null, State> {
@@ -21,6 +23,7 @@ class App extends React.Component<null, State> {
     this.state = {
       currentTheme: lightTheme,
       currentSorting: 'creationDate',
+      snackbarMessage: null,
     };
   }
 
@@ -36,8 +39,20 @@ class App extends React.Component<null, State> {
     });
   };
 
+  showSnackbar = (message: string): void => {
+    this.setState({
+      snackbarMessage: message,
+    });
+  };
+
+  hideSnackbar = (): void => {
+    this.setState({
+      snackbarMessage: null,
+    });
+  };
+
   render() {
-    const { currentTheme, currentSorting } = this.state;
+    const { currentTheme, currentSorting, snackbarMessage } = this.state;
     const sortingContextProviderValue = {
       currentSorting,
       changeSorting: this.changeSorting,
@@ -45,6 +60,10 @@ class App extends React.Component<null, State> {
     const themeContextProviderValue = {
       currentTheme,
       changeTheme: this.changeTheme,
+    };
+    const snackbarContextProviderValue = {
+      isSnackbarVisible: !!snackbarMessage,
+      showSnackbar: this.showSnackbar,
     };
 
     const actionBarBackgroundColor = currentTheme.dark ? currentTheme.colors.card : currentTheme.colors.primary;
@@ -59,28 +78,36 @@ class App extends React.Component<null, State> {
     return (
       <SortingContext.Provider value={sortingContextProviderValue}>
         <ThemeContext.Provider value={themeContextProviderValue}>
-          <NavigationContainer theme={currentTheme}>
-            <Stack.Navigator
-              initialRouteName="List"
-              screenOptions={defaultScreenOptions}
-            >
-              <Stack.Screen
-                name="List"
-                component={ListContainer}
-                options={{ title: 'Tasks list' }}
-              />
-              <Stack.Screen
-                name="Details"
-                component={DetailsContainer}
-                options={{ title: 'Task details' }}
-              />
-              <Stack.Screen
-                name="Settings"
-                component={SettingsContainer}
-                options={{ title: 'Settings' }}
-              />
-            </Stack.Navigator>
-          </NavigationContainer>
+          <SnackbarContext.Provider value={snackbarContextProviderValue}>
+            <NavigationContainer theme={currentTheme}>
+              <Stack.Navigator
+                initialRouteName="List"
+                screenOptions={defaultScreenOptions}
+              >
+                <Stack.Screen
+                  name="List"
+                  component={ListContainer}
+                  options={{ title: 'Tasks list' }}
+                />
+                <Stack.Screen
+                  name="Details"
+                  component={DetailsContainer}
+                  options={{ title: 'Task details' }}
+                />
+                <Stack.Screen
+                  name="Settings"
+                  component={SettingsContainer}
+                  options={{ title: 'Settings' }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
+
+            <StyledSnackbar
+              theme={this.state.currentTheme}
+              snackbarMessage={this.state.snackbarMessage}
+              onDismissSnackbar={this.hideSnackbar}
+            />
+          </SnackbarContext.Provider>
         </ThemeContext.Provider>
       </SortingContext.Provider>
     );

--- a/client/src/components/details/DetailsComponent.tsx
+++ b/client/src/components/details/DetailsComponent.tsx
@@ -1,30 +1,27 @@
 import React from 'react';
-import {ScrollView, StyleSheet, TouchableOpacity, View} from 'react-native';
-import {ActivityIndicator, TextInput, Text, RadioButton, Snackbar} from 'react-native-paper';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, RadioButton, Text, TextInput } from 'react-native-paper';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
 // @ts-ignore
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
-import {timeConverter, dateConverter} from '../../utils/dateTimeConverter';
-import {colors, fonts, margin, padding} from "../../styles/common";
-import {useTheme} from "@react-navigation/native";
-import SectionHeader from "../ui/SectionHeader";
+import { dateConverter, timeConverter } from '../../utils/dateTimeConverter';
+import { colors, fonts, margin, padding } from '../../styles/common';
+import { useTheme } from '@react-navigation/native';
+import SectionHeader from '../ui/SectionHeader';
 
 interface Props {
   handleConfirm: (data: Date) => void,
   isLoading: boolean,
   isModalVisible: boolean,
-  isSnackbarVisible: boolean,
   isSubmitting: boolean,
   onCancelClick: () => void,
   onClearIconClick: () => void,
   onDetailsChange: (text: string) => void,
-  onDismissSnackbar: () => void,
   onIconClick: () => void,
   onRadioButtonClick: (value: string) => void,
   onTitleChange: (text: string) => void,
   navigation: any,
   saveTask: () => void,
-  snackbarText: string,
   task: {
     title: string,
     details: string,
@@ -39,18 +36,15 @@ const DetailsComponent = (props: Props) => {
     handleConfirm,
     isLoading,
     isModalVisible,
-    isSnackbarVisible,
     isSubmitting,
     onCancelClick,
     onClearIconClick,
     onDetailsChange,
-    onDismissSnackbar,
     onIconClick,
     onRadioButtonClick,
     onTitleChange,
     navigation,
     saveTask,
-    snackbarText,
     task,
   } = props;
 
@@ -166,14 +160,6 @@ const DetailsComponent = (props: Props) => {
             </View>
 
           </ScrollView>
-          <Snackbar
-            theme={theme}
-            style={[styles.snackbar, {backgroundColor: theme.colors.card}]}
-            visible={isSnackbarVisible}
-            onDismiss={onDismissSnackbar}
-          >
-            {snackbarText}
-          </Snackbar>
         </>
       ) :
       <ActivityIndicator theme={theme} size='large' style={styles.activityIndicator}/>
@@ -219,10 +205,6 @@ const styles = StyleSheet.create({
   section: {
     marginTop: margin.vsm,
     marginBottom: margin.sm,
-  },
-  snackbar: {
-    position: 'absolute',
-    bottom: 0,
   },
   textInput: {
     margin: margin.sm,

--- a/client/src/components/details/DetailsContainer.tsx
+++ b/client/src/components/details/DetailsContainer.tsx
@@ -1,10 +1,12 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import DetailsComponent from './DetailsComponent';
 import { urlTasks } from '../../utils/APIClient';
+import { SnackbarContext } from '../../utils/context';
 
 interface Props {
   navigation: any,
   route: any,
+  showSnackbar: (message: string) => void;
 }
 
 interface State {
@@ -23,6 +25,8 @@ interface State {
 }
 
 class DetailsContainer extends Component<Props, State> {
+  static contextType = SnackbarContext;
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -69,7 +73,7 @@ class DetailsContainer extends Component<Props, State> {
         });
       })
       .catch((error) => {
-        this.showSnackbar('Error while fetching task.');
+        this.context.showSnackbar('Error while fetching task.');
       })
       .finally(() => this.setState({
         isLoading: false,
@@ -78,7 +82,7 @@ class DetailsContainer extends Component<Props, State> {
 
   isTaskValid = () => {
     if(!!this.state.task.title) return true;
-    this.showSnackbar('Title cannot be empty!');
+    this.context.showSnackbar('Title cannot be empty!');
     return false;
   };
 
@@ -108,10 +112,10 @@ class DetailsContainer extends Component<Props, State> {
     })
       .then((response: any) => {
         if(response) {
-          this.showSnackbar('Saved task!');
-          setTimeout(this.props.navigation.goBack, 2000);
+          this.context.showSnackbar('Saved task!');
+          this.props.navigation.goBack();
         } else {
-          this.showSnackbar('Error while saving task');
+          this.context.showSnackbar('Error while saving task');
           this.setState({
             isSubmitting: false,
           });
@@ -121,21 +125,8 @@ class DetailsContainer extends Component<Props, State> {
         this.setState({
           isSubmitting: false,
         });
-        this.showSnackbar('Something went wrong.');
+        this.context.showSnackbar('Something went wrong.');
       });
-  };
-
-  showSnackbar = (text: string) => {
-    this.setState({
-      snackbarText: text,
-      isSnackbarVisible: true,
-    });
-  };
-
-  onDismissSnackbar = () => {
-    this.setState({
-      isSnackbarVisible: false,
-    });
   };
 
   onIconClick = () => {
@@ -185,18 +176,15 @@ class DetailsContainer extends Component<Props, State> {
         handleConfirm={this.handleConfirm}
         isLoading={this.state.isLoading}
         isModalVisible={this.state.isModalVisible}
-        isSnackbarVisible={this.state.isSnackbarVisible}
         isSubmitting={this.state.isSubmitting}
         onCancelClick={this.onCancelClick}
         onClearIconClick={this.onClearIconClick}
         onDetailsChange={this.onDetailsChange}
-        onDismissSnackbar={this.onDismissSnackbar}
         onIconClick={this.onIconClick}
         onRadioButtonClick={this.onRadioButtonClick}
         onTitleChange={this.onTitleChange}
         navigation={this.props.navigation}
         saveTask={this.saveTask}
-        snackbarText={this.state.snackbarText}
         task={this.state.task}
       />
     );

--- a/client/src/components/ui/StyledSnackbar.tsx
+++ b/client/src/components/ui/StyledSnackbar.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Snackbar } from 'react-native-paper';
+import { Theme } from '@react-navigation/native/src/types';
+
+const styles = StyleSheet.create({
+  snackbar: {
+    position: 'absolute',
+    bottom: 0,
+  },
+});
+
+interface Props {
+  theme: Theme,
+  snackbarMessage: string | null;
+  onDismissSnackbar: () => void;
+}
+
+const StyledSnackbar = (props: Props) => (
+  <Snackbar
+    theme={props.theme}
+    style={[styles.snackbar, { backgroundColor: props.theme.colors.card }]}
+    duration={2000}
+    visible={!!props.snackbarMessage}
+    onDismiss={props.onDismissSnackbar}
+  >
+    {props.snackbarMessage}
+  </Snackbar>
+);
+
+export default StyledSnackbar;

--- a/client/src/utils/context.tsx
+++ b/client/src/utils/context.tsx
@@ -12,6 +12,11 @@ interface SortingContextInterface {
   changeSorting: (newSorting: string) => void;
 }
 
+interface SnackbarContextInterface {
+  isSnackbarVisible: boolean;
+  showSnackbar: (message: string) => void;
+}
+
 const ThemeContext: React.Context<ThemeContextInterface> = React.createContext({
   currentTheme: lightTheme,
   changeTheme: () => {
@@ -24,9 +29,18 @@ const SortingContext: React.Context<SortingContextInterface> = React.createConte
   },
 });
 
+// @ts-ignore
+const SnackbarContext: React.Context<SnackbarContextInterface> = React.createContext({
+  isSnackbarVisible: false,
+  showSnackbar: (_: string) => {
+  },
+});
+
 export {
   ThemeContextInterface,
   SortingContextInterface,
+  SnackbarContextInterface,
   ThemeContext,
   SortingContext,
+  SnackbarContext,
 };


### PR DESCRIPTION
Teraz `Snackbar` może być wyświetlany niezależnie od ekranu, to znaczy jest widoczny cały czas również wtedy, gdy nawigujemy do innego ekranu. Jedyne co to na liście tasków trochę nachodzi on na FAB, ale nie wiem co z tym zrobić 😛 